### PR TITLE
Remove *.xcworkspace from generated .gitignore

### DIFF
--- a/lib/liftoff.rb
+++ b/lib/liftoff.rb
@@ -4,5 +4,5 @@ require 'liftoff/git_helper'
 require 'liftoff/commands'
 
 module Liftoff
-  VERSION = '0.5'
+  VERSION = '0.5.1'
 end

--- a/lib/liftoff/git_helper.rb
+++ b/lib/liftoff/git_helper.rb
@@ -9,7 +9,6 @@ GITIGNORE_CONTENTS = <<GITIGNORE
 *.perspective
 *.perspectivev3
 *.pbxuser
-*.xcworkspace
 xcuserdata
 
 # Build products


### PR DESCRIPTION
- *.xcworkspace files are required for Cocoapods to work properly
- Bump version to 0.5.1
