### PR TITLE
Improve TODO/FIXME script for more filetypes

### DIFF
--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -2,7 +2,8 @@ require 'xcodeproj'
 
 TODO_WARNING_SCRIPT = <<WARNING
 KEYWORDS="TODO:|FIXME:|\\?\\?\\?:|\\!\\!\\!:"
-find "${SRCROOT}" -ipath "${SRCROOT}/pods" -prune -o \\( -name "*.h" -or -name "*.m" \\) -print0 | xargs -0 egrep --with-filename --line-number --only-matching "($KEYWORDS).*\\$" | perl -p -e "s/($KEYWORDS)/ warning: \\$1/"
+FILE_EXTENSIONS="h|m|mm|c|cpp"
+find -E "${SRCROOT}" -ipath "${SRCROOT}/pods" -prune -o \\( -regex ".*\\.($FILE_EXTENSIONS)$" \\) -print0 | xargs -0 egrep --with-filename --line-number --only-matching "($KEYWORDS).*\\$" | perl -p -e "s/($KEYWORDS)/ warning: \\$1/"
 WARNING
 
 HOSEY_WARNINGS = %w(


### PR DESCRIPTION
Use a regex to match filetypes instead of checking the filenames. This
makes expanding the script to support C++ files easier.
