### PR TITLE
AppCode specific files added to gitignore

### DIFF
--- a/lib/liftoff/git_helper.rb
+++ b/lib/liftoff/git_helper.rb
@@ -27,6 +27,10 @@ build/
 # Cocoapods
 Pods
 Podfile.lock
+
+# AppCode specific files
+.idea/
+*.iml
 GITIGNORE
 
 GITATTRIBUTES_CONTENTS = '*.pbxproj binary merge=union'


### PR DESCRIPTION
With my additions all AppCode specific files will be ignored by git. AppCode uses the Xcode project-settings, so all AppCode specific files should be local to the developers workstation.
