### PR TITLE
Remove the Podfile.lock from the default gitignore

### DIFF
--- a/lib/liftoff/git_helper.rb
+++ b/lib/liftoff/git_helper.rb
@@ -26,7 +26,6 @@ build/
 
 # Cocoapods
 Pods
-Podfile.lock
 
 # AppCode specific files
 .idea/


### PR DESCRIPTION
We no longer need to ignore this as of CocoaPods 0.17. We originally ignored
the file because of merge conflicts that were caused by CocoaPods reordering
the lock file on write, but that issue has been resolved and we haven't seen
any continuing issues in testing.

Fixes #30
