### PR TITLE
.pbxproj converted to plist old format

### DIFF
--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -30,7 +30,7 @@ class XcodeprojHelper
   XCODE_PROJECTS = Dir.glob("*.xcodeproj")
 
   def initialize
-    @project = Xcodeproj::Project.new(xcode_project_file)
+    @project = Xcodeproj::Project.open(xcode_project_file)
     @target = project_target
   end
 
@@ -118,6 +118,6 @@ class XcodeprojHelper
   end
 
   def save_changes
-    @project.save_as xcode_project_file
+    @project.save xcode_project_file
   end
 end

--- a/liftoff.gemspec
+++ b/liftoff.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/thoughtbot/liftoff'
 
   gem.add_dependency 'slop', '~> 3.4.4'
-  gem.add_dependency 'xcodeproj', '~> 0.5.1'
+  gem.add_dependency 'xcodeproj', '~> 0.14.1'
   gem.add_dependency 'highline', '~> 1.6'
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
when running liftoff on a new project, it changes the format of pbxproj. 

see diff after liftoff process: https://gist.github.com/netbe/7779087

This is related to the version of xcodeproj. So I updated it and  did not quite solve the problem directly (see https://github.com/CocoaPods/Xcodeproj/issues/84).

It finally did the trick when i got `xcproj`  installed :

```
brew install xcproj
```

kind of weird of `xcproj` needs to be installed, maybe the guys @cocoapods know more how to solve this.
