### PR TITLE
Remove binary flag from gitattributes

### DIFF
--- a/lib/liftoff/git_helper.rb
+++ b/lib/liftoff/git_helper.rb
@@ -33,7 +33,7 @@ Pods
 *.iml
 GITIGNORE
 
-GITATTRIBUTES_CONTENTS = '*.pbxproj binary merge=union'
+GITATTRIBUTES_CONTENTS = '*.pbxproj merge=union'
 
 class GitHelper
   def initialize


### PR DESCRIPTION
Recently, I've been removing this flag from the gitattributes. As far as I can
tell, it isn't actually changing the way git handles the merge. And I've found
myself wishing I could see the diff for the project file.
