### PR TITLE
Extract CLI class

### DIFF
--- a/bin/liftoff
+++ b/bin/liftoff
@@ -3,4 +3,4 @@
 $:.push File.expand_path("../../lib", __FILE__)
 require 'liftoff'
 
-Liftoff::LaunchPad.new(ARGV).liftoff
+Liftoff::CLI.new(ARGV).run

--- a/lib/liftoff/cli.rb
+++ b/lib/liftoff/cli.rb
@@ -1,0 +1,36 @@
+require 'optparse'
+
+module Liftoff
+  class CLI
+    def initialize(argv)
+      @argv = argv
+    end
+
+    def run
+      parse_command_line_options
+      Launchpad.new.liftoff
+    end
+
+    private
+
+    def parse_command_line_options
+      global_options.parse!(@argv)
+    end
+
+    def global_options
+      OptionParser.new do |opts|
+        opts.banner = 'usage: liftoff [-v | --version] [-h | --help]'
+
+        opts.on('-v', '--version', 'Display the version and exit') do
+          puts "Version: #{Liftoff::VERSION}"
+          exit 0
+        end
+
+        opts.on('-h', '--help', 'Display this help message and exit') do
+          puts opts
+          exit 0
+        end
+      end
+    end
+  end
+end

--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -1,14 +1,10 @@
-require 'optparse'
-
 module Liftoff
   class LaunchPad
-    def initialize(argv)
-      parse_command_line_options(argv)
+    def initialize
+      @config = ConfigurationParser.new.project_configuration
     end
 
     def liftoff
-      @config = ConfigurationParser.new.project_configuration
-
       generate_git
       set_indentation_level
       enable_warnings
@@ -18,26 +14,6 @@ module Liftoff
     end
 
     private
-
-    def parse_command_line_options(argv)
-      global_options.parse!(argv)
-    end
-
-    def global_options
-      OptionParser.new do |opts|
-        opts.banner = 'usage: liftoff [-v | --version] [-h | --help]'
-
-        opts.on('-v', '--version', 'Display the version and exit') do
-          puts "Version: #{Liftoff::VERSION}"
-          exit 0
-        end
-
-        opts.on('-h', '--help', 'Display this help message and exit') do
-          puts opts
-          exit 0
-        end
-      end
-    end
 
     def generate_git
       FileManager.new.create_git_files(@config[:git])


### PR DESCRIPTION
This pulls the CLI functionality out of Launchpad, which cleans up that class
nicely.
