### PR TITLE
Link `xcassets` as a resource instead of a source

### DIFF
--- a/lib/liftoff/project_builder.rb
+++ b/lib/liftoff/project_builder.rb
@@ -60,7 +60,9 @@ module Liftoff
       rendered_template_name = string_renderer.render(raw_template_name)
       file = parent_group.new_file(rendered_template_name)
 
-      if linkable_file?(rendered_template_name)
+      if resource_file?(rendered_template_name)
+        target.add_resources([file])
+      elsif linkable_file?(rendered_template_name)
         target.add_file_references([file])
       else
         add_file_to_build_settings(rendered_template_name, path, target)
@@ -81,6 +83,10 @@ module Liftoff
 
     def linkable_file?(name)
       !name.end_with?('h', 'plist')
+    end
+
+    def resource_file?(name)
+      name.end_with?('xcassets')
     end
 
     def template_file?(object)


### PR DESCRIPTION
Previously, we were adding the `xcassets` catalogue as a source file instead
of as a resource. This meant that we actually didn't have a
'Copy Bundle Resources' build phase created, and our asset catalogue was 
technically being linked into the application incorrectly.

Fixes #78
