### PR TITLE
Update imports in templates

### DIFF
--- a/templates/<%= project_name %>-Prefix.pch
+++ b/templates/<%= project_name %>-Prefix.pch
@@ -5,6 +5,6 @@
 #endif
 
 #ifdef __OBJC__
-    #import <UIKit/UIKit.h>
-    #import <Foundation/Foundation.h>
+    @import UIKit;
+    @import Foundation;
 #endif

--- a/templates/UnitTests-Prefix.pch
+++ b/templates/UnitTests-Prefix.pch
@@ -7,6 +7,6 @@
     #import <Expecta/Expecta.h>
     #import <OCMock/OCMock.h>
 <% else %>
-    #import <XCTest/XCTest.h>
+    @import XCTest;
 <% end %>
 #endif

--- a/templates/main.m
+++ b/templates/main.m
@@ -6,7 +6,7 @@
 //  Copyright (c) <%= Time.now.strftime('%Y') %> <%= company %>. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 #import "<%= prefix %>AppDelegate.h"
 


### PR DESCRIPTION
- `@import` is so hot right now.
- The UIKit import in main.m is unnecessary since it's declared in the precompiled header.
