### PR TITLE
Add default pods for test target

### DIFF
--- a/templates/Podfile
+++ b/templates/Podfile
@@ -1,1 +1,8 @@
 platform :ios, '7.0'
+
+target :unit_tests, :exclusive => true do
+  link_with 'UnitTests'
+  pod 'Specta'
+  pod 'Expecta'
+  pod 'OCMock'
+end

--- a/templates/UnitTests-Prefix.pch
+++ b/templates/UnitTests-Prefix.pch
@@ -1,4 +1,10 @@
 #import "<%= project_name %>-Prefix.pch"
 
 #ifdef __OBJC__
+<% if use_cocoapods %>
+    #define SPC_SHORTHAND
+    #import <Specta/Specta.h>
+    #import <Expecta/Expecta.h>
+    #import <OCMock/OCMock.h>
+<% end %>
 #endif


### PR DESCRIPTION
- Add Specta, Expecta, and OCMock to default podfile
- Add testing dependencies to the prefix if cocoapods is enabled
