### PR TITLE
Set SDKROOT at the project level

### DIFF
--- a/lib/liftoff/project.rb
+++ b/lib/liftoff/project.rb
@@ -70,6 +70,7 @@ module Liftoff
         configuration.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = 'iPhone Developer'
         configuration.build_settings['ASSETCATALOG_COMPILER_APPICON_NAME'] = 'AppIcon'
         configuration.build_settings['ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME'] = 'LaunchImage'
+        configuration.build_settings['SDKROOT'] = 'iphoneos'
       end
     end
 


### PR DESCRIPTION
Xcode sets the SDKROOT at the project level. This changes the way that Xcode
sets the paths for imported frameworks, among other things.

Fixes #97
