### PR TITLE
Add company_identifier property to configuration

### DIFF
--- a/lib/liftoff/option_fetcher.rb
+++ b/lib/liftoff/option_fetcher.rb
@@ -7,6 +7,7 @@ module Liftoff
     def fetch_options
       fetch_option_for(:project_name, 'Project name')
       fetch_option_for(:company, 'Company name')
+      fetch_option_for(:company_identifier, 'Company identifier')
       fetch_option_for(:author, 'Author name')
       fetch_option_for(:prefix, 'Prefix')
     end

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -1,6 +1,7 @@
 module Liftoff
   class ProjectConfiguration
     attr_accessor :project_name, :company, :author, :prefix, :configure_git, :warnings_as_errors, :install_todo_script, :enable_static_analyzer, :indentation_level, :warnings, :application_target_groups, :unit_test_target_groups, :use_cocoapods
+    attr_writer :company_identifier
 
     def initialize(liftoffrc)
       liftoffrc.each_pair do |attribute, value|
@@ -13,8 +14,18 @@ module Liftoff
       end
     end
 
+    def company_identifier
+      @company_identifier || "com.#{normalized_company_name}"
+    end
+
     def get_binding
       binding
+    end
+
+    private
+
+    def normalized_company_name
+      company.gsub(/[^0-9a-z]/i, '').downcase
     end
   end
 end

--- a/man/liftoffrc.5
+++ b/man/liftoffrc.5
@@ -143,6 +143,17 @@ default: none
 .Pp
 Set the default value for the company name when generating new projects. Not
 defined by default.
+.It Ic company_identifier
+type: string
+.br
+default: based on company name
+.Pp
+Set the default value for the company identifier when generating new projects.
+Default value is the provided company name, downcased and stripped of special
+characters. For example:
+.Ic My Company Name!
+becomes
+.Ic com.mycompanyname .
 .It Ic author
 type: string
 .br

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Liftoff::ProjectConfiguration do
+  describe '#company_identifier' do
+    context 'when the identifier is set directly' do
+      it 'returns the given identifier' do
+        config = ProjectConfiguration.new({})
+        config.company_identifier = 'foo'
+
+        expect(config.company_identifier).to eq 'foo'
+      end
+    end
+
+    context 'when the identifier is not set directly' do
+      it 'returns a reverse domain string from the normalized company name' do
+        config = ProjectConfiguration.new({})
+        config.company = 'My Cool Company!'
+
+        expect(config.company_identifier).to eq 'com.mycoolcompany'
+      end
+    end
+  end
+end

--- a/templates/<%= project_name %>-Info.plist
+++ b/templates/<%= project_name %>-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.<%= company %>.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string><%= company_identifier %>.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/templates/UnitTests-Info.plist
+++ b/templates/UnitTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.<%= company %>.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string><%= company_identifier %>.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
This allows users to provide (or pre-define using the liftoffrc) a company
identifier to use for the project. By default, we will construct a company
identifier for the user by normalizing the provided company name and
prepending 'com.'

Fixes #94
