### PR TITLE
Automatically default to the current user's name

### DIFF
--- a/lib/liftoff/option_fetcher.rb
+++ b/lib/liftoff/option_fetcher.rb
@@ -8,7 +8,6 @@ module Liftoff
       fetch_option_for(:project_name, 'Project name')
       fetch_option_for(:company, 'Company name')
       fetch_option_for(:company_identifier, 'Company identifier')
-      fetch_option_for(:author, 'Author name')
       fetch_option_for(:prefix, 'Prefix')
     end
 

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -1,7 +1,9 @@
+require 'etc'
+
 module Liftoff
   class ProjectConfiguration
-    attr_accessor :project_name, :company, :author, :prefix, :configure_git, :warnings_as_errors, :install_todo_script, :enable_static_analyzer, :indentation_level, :warnings, :application_target_groups, :unit_test_target_groups, :use_cocoapods
-    attr_writer :company_identifier
+    attr_accessor :project_name, :company, :prefix, :configure_git, :warnings_as_errors, :install_todo_script, :enable_static_analyzer, :indentation_level, :warnings, :application_target_groups, :unit_test_target_groups, :use_cocoapods
+    attr_writer :author, :company_identifier
 
     def initialize(liftoffrc)
       liftoffrc.each_pair do |attribute, value|
@@ -12,6 +14,10 @@ module Liftoff
           exit 1
         end
       end
+    end
+
+    def author
+      @author || Etc.getpwuid.gecos.split(',').first
     end
 
     def company_identifier

--- a/man/liftoffrc.5
+++ b/man/liftoffrc.5
@@ -157,10 +157,13 @@ becomes
 .It Ic author
 type: string
 .br
-default: none
+default: Pulled from the
+.Ic gecos
+field in
+.Xr passwd 5
 .Pp
-Set the default value for the author name when generating new projects. Not
-enabled by default.
+Set the default value for the author name when generating new projects. The
+current user's name will be automatically set as the default.
 .It Ic prefix
 type: string
 .br

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -4,7 +4,7 @@ describe Liftoff::ProjectConfiguration do
   describe '#company_identifier' do
     context 'when the identifier is set directly' do
       it 'returns the given identifier' do
-        config = ProjectConfiguration.new({})
+        config = Liftoff::ProjectConfiguration.new({})
         config.company_identifier = 'foo'
 
         expect(config.company_identifier).to eq 'foo'
@@ -13,10 +13,31 @@ describe Liftoff::ProjectConfiguration do
 
     context 'when the identifier is not set directly' do
       it 'returns a reverse domain string from the normalized company name' do
-        config = ProjectConfiguration.new({})
+        config = Liftoff::ProjectConfiguration.new({})
         config.company = 'My Cool Company!'
 
         expect(config.company_identifier).to eq 'com.mycoolcompany'
+      end
+    end
+  end
+
+  describe '#author' do
+    context 'when the author name is set directly' do
+      it 'returns the given author name' do
+        config = Liftoff::ProjectConfiguration.new({})
+        config.author = 'Bunk Moreland'
+
+        expect(config.author).to eq 'Bunk Moreland'
+      end
+    end
+
+    context 'when the author name is not set directly' do
+      it 'returns the name of the current user from passwd(5)' do
+        config = Liftoff::ProjectConfiguration.new({})
+        getpwuid = double('getpwuid', gecos: 'Jimmy McNulty')
+        Etc.stub(:getpwuid) { getpwuid }
+
+        expect(config.author).to eq 'Jimmy McNulty'
       end
     end
   end


### PR DESCRIPTION
Pull the current user's name from `passwd(5)` by default.

Credit to @mike-burns for the technique

Fixes #80
