### PR TITLE
Remove OTHER_LDFLAGS from target

### DIFF
--- a/lib/liftoff/project.rb
+++ b/lib/liftoff/project.rb
@@ -36,6 +36,9 @@ module Liftoff
 
     def new_app_target
       target = xcode_project.new_target(:application, @name, :ios, 7.0)
+      target.build_configurations.each do |configuration|
+        configuration.build_settings.delete('OTHER_LDFLAGS')
+      end
       target
     end
 


### PR DESCRIPTION
Xcodeproj (incorrectly) adds a blank value for OTHER_LDFLAGS when creating a
new application target. For now, we should just delete the key from the
configurations.

Fixes #111
