### PR TITLE
Disable RubyGems

### DIFF
--- a/src/liftoff
+++ b/src/liftoff
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/ruby --disable-gems
 
 require 'pathname'
 


### PR DESCRIPTION
Apparently, there were some cases where we were getting conflicts with the
Xcodeproj native C extensions because RubyGems insisted on loading itself. By
explicitly disabling RubyGems inside the shebang, we can make sure that this
doesn't happen.

Fixes #113 (amazingly)
