### PR TITLE
Be more specific about not linking Info.plist file

### DIFF
--- a/lib/liftoff/project_builder.rb
+++ b/lib/liftoff/project_builder.rb
@@ -82,7 +82,7 @@ module Liftoff
     end
 
     def linkable_file?(name)
-      !name.end_with?('h', 'plist')
+      !name.end_with?('h', 'Info.plist')
     end
 
     def resource_file?(name)


### PR DESCRIPTION
Previously, we were filtering out all plists from being linked against the
target. However, in actuality, we should allow users to link template plists,
and only prevent the linking of Info.plist files.

Fixes #121
