### PR TITLE
Centralize deployment target

### DIFF
--- a/lib/liftoff/project.rb
+++ b/lib/liftoff/project.rb
@@ -1,9 +1,10 @@
 module Liftoff
   class Project
-    def initialize(name, company, prefix)
-      @name = name
-      set_company_name(company)
-      set_prefix(prefix)
+    def initialize(configuration)
+      @name = configuration.project_name
+      @deployment_target = configuration.deployment_target
+      set_company_name(configuration.company)
+      set_prefix(configuration.prefix)
       configure_base_project_settings
     end
 
@@ -35,9 +36,10 @@ module Liftoff
     end
 
     def new_app_target
-      target = xcode_project.new_target(:application, @name, :ios, 7.0)
+      target = xcode_project.new_target(:application, @name, :ios)
       target.build_configurations.each do |configuration|
         configuration.build_settings.delete('OTHER_LDFLAGS')
+        configuration.build_settings.delete('IPHONEOS_DEPLOYMENT_TARGET')
       end
       target
     end
@@ -70,6 +72,7 @@ module Liftoff
         configuration.build_settings['ASSETCATALOG_COMPILER_APPICON_NAME'] = 'AppIcon'
         configuration.build_settings['ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME'] = 'LaunchImage'
         configuration.build_settings['SDKROOT'] = 'iphoneos'
+        configuration.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = @deployment_target
       end
     end
 

--- a/lib/liftoff/project_builder.rb
+++ b/lib/liftoff/project_builder.rb
@@ -106,7 +106,7 @@ module Liftoff
     end
 
     def xcode_project
-      @xcode_project ||= Project.new(@project_configuration.project_name, @project_configuration.company, @project_configuration.prefix)
+      @xcode_project ||= Project.new(@project_configuration)
     end
 
     def file_manager

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -1,5 +1,7 @@
 module Liftoff
   class ProjectConfiguration
+    LATEST_IOS = 7.0
+
     attr_accessor :project_name, :company, :prefix, :configure_git, :warnings_as_errors, :install_todo_script, :enable_static_analyzer, :indentation_level, :warnings, :application_target_groups, :unit_test_target_groups, :use_cocoapods
     attr_writer :author, :company_identifier
 
@@ -20,6 +22,10 @@ module Liftoff
 
     def company_identifier
       @company_identifier || "com.#{normalized_company_name}"
+    end
+
+    def deployment_target
+      LATEST_IOS
     end
 
     def get_binding

--- a/templates/<%= project_name %>-Prefix.pch
+++ b/templates/<%= project_name %>-Prefix.pch
@@ -1,7 +1,7 @@
 #import <Availability.h>
 
-#ifndef __IPHONE_7_0
-#warning "This project uses features only available in iOS SDK 7.0 and later."
+#ifndef __IPHONE_<%= deployment_target.to_s.gsub('.', '_') %>
+#warning "This project uses features only available in iOS SDK <%= deployment_target %> and later."
 #endif
 
 #ifdef __OBJC__

--- a/templates/Podfile
+++ b/templates/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '7.0'
+platform :ios, '<%= deployment_target %>'
 
 target :unit_tests, :exclusive => true do
   link_with 'UnitTests'


### PR DESCRIPTION
- Set the deployment target at the project level instead of at the
  target level. This mimics the behavior of Xcode.
- Configure the deployment target with ProjectConfiguration.
- Use the deployment target information to populate values inside
  templates.
