### PR TITLE
Reluctantly allow the use of tabs for indentation

### DIFF
--- a/defaults/liftoffrc
+++ b/defaults/liftoffrc
@@ -11,6 +11,7 @@ warnings_as_errors: true
 install_todo_script: true
 enable_static_analyzer: true
 indentation_level: 4
+use_tabs: false
 use_cocoapods: true
 
 warnings:

--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -48,7 +48,7 @@ module Liftoff
     end
 
     def set_indentation_level
-      xcode_helper.set_indentation_level(@config.indentation_level)
+      xcode_helper.set_indentation_level(@config.indentation_level, @config.use_tabs)
     end
 
     def treat_warnings_as_errors

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -3,7 +3,7 @@ module Liftoff
     LATEST_IOS = 7.0
 
     attr_accessor :project_name, :company, :prefix, :configure_git, :warnings_as_errors, :install_todo_script, :enable_static_analyzer, :indentation_level, :warnings, :application_target_groups, :unit_test_target_groups, :use_cocoapods
-    attr_writer :author, :company_identifier
+    attr_writer :author, :company_identifier, :use_tabs
 
     def initialize(liftoffrc)
       liftoffrc.each_pair do |attribute, value|
@@ -22,6 +22,14 @@ module Liftoff
 
     def company_identifier
       @company_identifier || "com.#{normalized_company_name}"
+    end
+
+    def use_tabs
+      if @use_tabs
+        '1'
+      else
+        '0'
+      end
     end
 
     def deployment_target

--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -27,13 +27,13 @@ module Liftoff
       end
     end
 
-    def set_indentation_level(level)
+    def set_indentation_level(level, use_tabs)
       if level
-        puts "Setting the project indentation level to #{level} spaces"
+        puts "Setting the project indentation level to #{level}"
         main_group = xcode_project.main_group
         main_group.indent_width = level.to_s
         main_group.tab_width = level.to_s
-        main_group.uses_tabs = '0'
+        main_group.uses_tabs = use_tabs
       end
     end
 

--- a/man/liftoffrc.5
+++ b/man/liftoffrc.5
@@ -104,7 +104,22 @@ type: integer
 default:
 .Ic 4
 .Pp
-Set the indentation level on the project (in spaces).
+Set the indentation width on the project (in spaces).
+.It Ic use_tabs
+type: boolean
+.br
+default:
+.Ic false
+.Pp
+Configure the project to use spaces or tabs for indentation. As everyone knows,
+you should really be using spaces for indentation. If you prefer to be wrong,
+however, you can change this configuration to use tabs in your project.
+.Pp
+Note that this does
+.Em not
+affect the default templates. If you choose to be incorrect with your
+indentation settings, we recommend that you also override the default templates
+in order to be consistently wrong.
 .It Ic warnings
 type: array
 .br


### PR DESCRIPTION
Everyone knows that you _should_ be using spaces for indentation and not tabs,
but some people insist on being wrong, so we shouldn't make it hard for them
to be wrong.

This adds a `use_tabs` key to the configuration. By default, this key is 
false, the way God intended, but people that feel like being insane can change
it to configure their project to use tabs instead of spaces.

Note that this _doesn't_ affect the templates. It's recommended that if you
want to use tabs everywhere, you override the templates to match.

Fixes #119
