### PR TITLE
Add pods to default podspec for network stubbing

### DIFF
--- a/templates/Podfile
+++ b/templates/Podfile
@@ -8,5 +8,4 @@ target :unit_tests, :exclusive => true do
   pod 'Expecta'
   pod 'OCMock'
   pod 'OHHTTPStubs'
-  pod 'XCTest+OHHTTPStubSuiteCleanUp'
 end


### PR DESCRIPTION
- OHHTTPStubs is a fantastic library for quickly and easily stubbing
  network requests
- XCTest+OHHTTPStubSuiteCleanUp ensures that all stubs are reset after
  each test. This ensures that tests aren't dependent on interacting
  with each other. Just including this pod enables this feature. There
  is no need to import the pod anywhere.
