### PR TITLE
Add documentation hint to default Podfile

### DIFF
--- a/templates/Podfile
+++ b/templates/Podfile
@@ -1,5 +1,7 @@
 platform :ios, '<%= deployment_target %>'
 
+# Add Application pods here
+
 target :unit_tests, :exclusive => true do
   link_with 'UnitTests'
   pod 'Specta'


### PR DESCRIPTION
In #144, there was some confusion caused by adding pods to the wrong
target. In an effort to prevent this confusion in the future, I'd like
to add a little hint in the form of a comment to the default Podfile.
