### PR TITLE
Don't skip installation for app targets

### DIFF
--- a/lib/liftoff/project.rb
+++ b/lib/liftoff/project.rb
@@ -40,6 +40,7 @@ module Liftoff
       target.build_configurations.each do |configuration|
         configuration.build_settings.delete('OTHER_LDFLAGS')
         configuration.build_settings.delete('IPHONEOS_DEPLOYMENT_TARGET')
+        configuration.build_settings.delete('SKIP_INSTALL')
       end
       target
     end


### PR DESCRIPTION
This change is to keep us in line with the default configuration from Xcode.
If this setting is on, Archiving completely fails, which is super annoying and
it isn't obvious how to fix it.

Fixes #149 
