### PR TITLE
Generate application scheme manually

### DIFF
--- a/lib/liftoff/file_manager.rb
+++ b/lib/liftoff/file_manager.rb
@@ -8,13 +8,6 @@ module Liftoff
       exit 1
     end
 
-    def move_scheme(project_name)
-      shared_schemes = "#{project_name}.xcodeproj/xcshareddata/xcschemes"
-      original_scheme = Dir.glob("**/#{project_name}.xcscheme").first
-      FileUtils.mkdir_p(shared_schemes)
-      FileUtils.mv(original_scheme, shared_schemes)
-    end
-
     def generate(template, destination = template, project_config = ProjectConfiguration.new({}))
       puts "Writing #{destination}"
       create_destination_path(destination)

--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -12,7 +12,6 @@ module Liftoff
           generate_project
           install_cocoapods
           generate_templates
-          share_scheme
           perform_project_actions
           open_project
         end
@@ -40,11 +39,6 @@ module Liftoff
 
     def generate_templates
       TemplateGenerator.new.generate_templates(@config, file_manager)
-    end
-
-    def share_scheme
-      xcode_helper.create_schemes
-      file_manager.move_scheme(@config.project_name)
     end
 
     def generate_project

--- a/lib/liftoff/project.rb
+++ b/lib/liftoff/project.rb
@@ -25,6 +25,14 @@ module Liftoff
       xcode_project.new_group(name, path)
     end
 
+    def generate_scheme
+      scheme = Xcodeproj::XCScheme.new
+      scheme.add_build_target(app_target)
+      scheme.add_test_target(unit_test_target)
+      scheme.set_launch_target(app_target)
+      scheme.save_as(xcode_project.path, @name)
+    end
+
     private
 
     def reorder_groups

--- a/lib/liftoff/project_builder.rb
+++ b/lib/liftoff/project_builder.rb
@@ -13,6 +13,7 @@ module Liftoff
       end
 
       xcode_project.save
+      xcode_project.generate_scheme
     end
 
     private

--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -36,7 +36,7 @@ module Liftoff
         main_group.uses_tabs = use_tabs
       end
     end
-    
+
     def add_script_phases(scripts)
       if scripts
         scripts.each do |script|
@@ -45,10 +45,6 @@ module Liftoff
           add_shell_script_build_phase(file_manager.template_contents(key), value)
         end
       end
-    end
-
-    def create_schemes
-      xcode_project.recreate_user_schemes(true)
     end
 
     def save


### PR DESCRIPTION
Letting Xcodeproj create the schemes for us didn't work super well. It created
a scheme for each target individually, and there was no way to set the test
target. We also had to manually move the scheme from the user's data directory
to the shared directory.

Note that at this moment, Xcodeproj sets the testable bundle name to 
name.ocunit instead of xctest. Xcode corrects this when it opens the project,
leading to a dirty repo.
