### PR TITLE
Update xcodeproj to newest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :dist do
-  gem 'xcodeproj', '~> 0.14.1'
+  gem 'xcodeproj', '~> 0.19.2'
   gem 'highline', '~> 1.6'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.18)
+    CFPropertyList (2.2.8)
+    activesupport (3.2.19)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     colored (1.2)
     diff-lcs (1.2.5)
     highline (1.6.21)
-    i18n (0.6.9)
-    multi_json (1.10.0)
-    rake (10.3.1)
+    i18n (0.6.11)
+    multi_json (1.10.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -18,10 +18,10 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
-    xcodeproj (0.14.1)
+    xcodeproj (0.19.2)
+      CFPropertyList (~> 2.2)
       activesupport (~> 3.0)
       colored (~> 1.2)
-      rake
 
 PLATFORMS
   ruby
@@ -29,4 +29,4 @@ PLATFORMS
 DEPENDENCIES
   highline (~> 1.6)
   rspec
-  xcodeproj (~> 0.14.1)
+  xcodeproj (~> 0.19.2)

--- a/lib/liftoff/project.rb
+++ b/lib/liftoff/project.rb
@@ -81,7 +81,7 @@ module Liftoff
         configuration.build_settings['ASSETCATALOG_COMPILER_APPICON_NAME'] = 'AppIcon'
         configuration.build_settings['ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME'] = 'LaunchImage'
         configuration.build_settings['SDKROOT'] = 'iphoneos'
-        configuration.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = @deployment_target
+        configuration.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = @deployment_target.to_s
       end
     end
 


### PR DESCRIPTION
This removes xcodeproj's dependency on a native C extension, which should make
_everything_ better. It also fixes some load issues on 10.10
