### PR TITLE
Simplify the status output

### DIFF
--- a/lib/liftoff/file_manager.rb
+++ b/lib/liftoff/file_manager.rb
@@ -9,7 +9,6 @@ module Liftoff
     end
 
     def generate(template, destination = template, project_config = ProjectConfiguration.new({}))
-      puts "Writing #{destination}"
       create_destination_path(destination)
       template_path = TemplateFinder.new.template_path(template)
       if template_is_directory?(template_path)
@@ -21,7 +20,6 @@ module Liftoff
 
     def mkdir_gitkeep(path)
       dir_path = File.join(*path)
-      puts "Creating #{dir_path}"
       FileUtils.mkdir_p(dir_path)
       FileUtils.touch(File.join(dir_path, '.gitkeep'))
     end

--- a/lib/liftoff/project_builder.rb
+++ b/lib/liftoff/project_builder.rb
@@ -6,6 +6,7 @@ module Liftoff
     end
 
     def create_project
+      puts "Generating the '#{@project_configuration.project_template}' project template"
       groups_and_targets.each do |groups, target|
         groups.each do |group|
           create_tree(group, target)


### PR DESCRIPTION
This was printing a whole bunch of stuff to STDOUT that probably wasn't too
useful. Instead, we can just say that we're generating the given project
template.
