### PR TITLE
Force encoding to UTF-8 when normalizing comp name

### DIFF
--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -83,7 +83,7 @@ module Liftoff
     private
 
     def normalized_company_name
-      company.gsub(/[^0-9a-z]/i, '').downcase
+      company.force_encoding('UTF-8').gsub(/[^0-9a-z]/i, '').downcase
     end
   end
 end

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -18,6 +18,13 @@ describe Liftoff::ProjectConfiguration do
 
         expect(config.company_identifier).to eq 'com.mycoolcompany'
       end
+
+      it 'forces the encoding to utf-8' do
+        config = Liftoff::ProjectConfiguration.new({})
+        config.company = "My Cool\xC2\xB7Company!".force_encoding('US-ASCII')
+
+        expect(config.company_identifier).to eq 'com.mycoolcompany'
+      end
     end
   end
 


### PR DESCRIPTION
This fixes a crash on non `en_US.UTF-8` systems

Fixes #171 
