### PR TITLE
Force encoding to UTF-8 when normalizing comp name

### DIFF
--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -80,7 +80,7 @@ module Liftoff
     private
 
     def normalized_company_name
-      company.gsub(/[^0-9a-z]/i, '').downcase
+      company.force_encoding('utf-8').gsub(/[^0-9a-z]/i, '').downcase
     end
   end
 end


### PR DESCRIPTION
This fixes a crash on non `en_US.UTF-8` systems
