### PR TITLE
Move Resources folder under project name for objc

### DIFF
--- a/defaults/liftoffrc
+++ b/defaults/liftoffrc
@@ -67,16 +67,16 @@ app_target_templates:
         - <%= prefix %>AppDelegate.h
         - <%= prefix %>AppDelegate.m
       - Views:
-    - Resources:
-      - Images.xcassets
-      - Storyboards:
-        - Main.storyboard
-      - Nibs:
-        - LaunchScreen.xib
-      - Other-Sources:
-        - Info.plist
-        - <%= project_name %>-Prefix.pch
-        - main.m
+      - Resources:
+        - Images.xcassets
+        - Storyboards:
+          - Main.storyboard
+        - Nibs:
+          - LaunchScreen.xib
+        - Other-Sources:
+          - Info.plist
+          - <%= project_name %>-Prefix.pch
+          - main.m
   swift:
     - <%= project_name %>:
       - Extensions:


### PR DESCRIPTION
The default objc template accidentally had the Resources folder sitting in the
root of the project, instead of under the project name folder. The default
Swift template already handles this properly.

Fixes #194
