### PR TITLE
Allow to override the deployment target

### DIFF
--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -20,7 +20,8 @@ module Liftoff
       :run_script_phases,
       :strict_prompts,
       :xcode_command,
-      :extra_config
+      :extra_config,
+      :deployment_target
 
     attr_writer :author,
       :company_identifier,
@@ -56,7 +57,7 @@ module Liftoff
     end
 
     def deployment_target
-      LATEST_IOS
+      @deployment_target || LATEST_IOS
     end
 
     def each_template(&block)


### PR DESCRIPTION
The deployment target can now be set by specifying it in the liftoffrc file, it will override the default of LATEST_IOS
