### PR TITLE
Set default deployment target in liftoffrc

### DIFF
--- a/defaults/liftoffrc
+++ b/defaults/liftoffrc
@@ -16,6 +16,7 @@ use_tabs: false
 use_cocoapods: true
 enable_settings: true
 strict_prompts: false
+deployment_target: 8.0
 
 run_script_phases:
   - todo.sh: Warn for TODO and FIXME comments

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -1,7 +1,5 @@
 module Liftoff
   class ProjectConfiguration
-    LATEST_IOS = 8.0
-
     attr_accessor :project_name,
       :company,
       :prefix,
@@ -54,10 +52,6 @@ module Liftoff
       else
         '0'
       end
-    end
-
-    def deployment_target
-      @deployment_target || LATEST_IOS
     end
 
     def each_template(&block)


### PR DESCRIPTION
With the deployment target able to be configured in the user's liftoffrc, it
makes more sense for us to define the default there as well.

related: #199
