### PR TITLE
Allow the user to specify a path from the CLI (#77)

### DIFF
--- a/lib/liftoff/cli.rb
+++ b/lib/liftoff/cli.rb
@@ -7,13 +7,14 @@ module Liftoff
 
     def run
       parse_command_line_options
-      LaunchPad.new.liftoff @options, @argv.first
+      LaunchPad.new.liftoff @options
     end
 
     private
 
     def parse_command_line_options
       global_options.parse!(@argv)
+      @options[:path] = @argv.first
     end
 
     def global_options

--- a/lib/liftoff/cli.rb
+++ b/lib/liftoff/cli.rb
@@ -7,7 +7,7 @@ module Liftoff
 
     def run
       parse_command_line_options
-      LaunchPad.new.liftoff @options
+      LaunchPad.new.liftoff @options, @argv.first
     end
 
     private
@@ -18,7 +18,7 @@ module Liftoff
 
     def global_options
       OptionParser.new do |opts|
-        opts.banner = 'usage: liftoff [-v | --version] [-h | --help] [config options]'
+        opts.banner = 'usage: liftoff [-v | --version] [-h | --help] [config options] [path]'
 
         opts.on('-v', '--version', 'Display the version and exit') do
           puts "Version: #{Liftoff::VERSION}"

--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -2,7 +2,7 @@ module Liftoff
   class LaunchPad
     EX_NOINPUT = 66
 
-    def liftoff(options)
+    def liftoff(options, path)
       liftoffrc = ConfigurationParser.new(options).project_configuration
       @config = ProjectConfiguration.new(liftoffrc)
       if project_exists?
@@ -11,7 +11,7 @@ module Liftoff
         validate_template
         fetch_options
 
-        file_manager.create_project_dir(@config.project_name) do
+        file_manager.create_project_dir(path ? path : @config.project_name) do
           generate_project
           setup_cocoapods
           generate_templates

--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -2,9 +2,9 @@ module Liftoff
   class LaunchPad
     EX_NOINPUT = 66
 
-    def liftoff(options, path)
+    def liftoff(options)
       liftoffrc = ConfigurationParser.new(options).project_configuration
-      @config = ProjectConfiguration.new(liftoffrc, path)
+      @config = ProjectConfiguration.new(liftoffrc)
       if project_exists?
         perform_project_actions
       else

--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -4,14 +4,14 @@ module Liftoff
 
     def liftoff(options, path)
       liftoffrc = ConfigurationParser.new(options).project_configuration
-      @config = ProjectConfiguration.new(liftoffrc)
+      @config = ProjectConfiguration.new(liftoffrc, path)
       if project_exists?
         perform_project_actions
       else
         validate_template
         fetch_options
 
-        file_manager.create_project_dir(path ? path : @config.project_name) do
+        file_manager.create_project_dir(@config.path) do
           generate_project
           setup_cocoapods
           generate_templates

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -26,8 +26,7 @@ module Liftoff
       :use_tabs,
       :path
 
-    def initialize(liftoffrc, path = nil)
-      @path = path
+    def initialize(liftoffrc)
       deprecations = DeprecationManager.new
       liftoffrc.each_pair do |attribute, value|
         if respond_to?("#{attribute}=")

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -23,9 +23,11 @@ module Liftoff
 
     attr_writer :author,
       :company_identifier,
-      :use_tabs
+      :use_tabs,
+      :path
 
-    def initialize(liftoffrc)
+    def initialize(liftoffrc, path = nil)
+      @path = path
       deprecations = DeprecationManager.new
       liftoffrc.each_pair do |attribute, value|
         if respond_to?("#{attribute}=")
@@ -74,6 +76,9 @@ module Liftoff
       @test_target_templates[@project_template]
     end
 
+    def path
+      @path || project_name
+    end
     private
 
     def normalized_company_name

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -109,6 +109,28 @@ describe Liftoff::ProjectConfiguration do
     end
   end
 
+  describe '#path' do
+    context 'when the path is not given in the constructor' do
+      it 'return the project name' do
+        config = Liftoff::ProjectConfiguration.new({
+          :project_name => 'My Cool Project'
+        })
+
+        expect(config.path).to eq 'My Cool Project'
+      end
+
+    end
+
+    context 'when the path is given by constructor' do
+      it 'return the given path' do
+        config = Liftoff::ProjectConfiguration.new({}, 'Another Path')
+
+        expect(config.path).to eq 'Another Path'
+      end
+    end
+
+  end
+
   def build_config(name)
     app_templates = build_templates('app')
     test_templates = build_templates('test')

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -111,7 +111,7 @@ describe Liftoff::ProjectConfiguration do
 
   describe '#path' do
     context 'when the path is not given in the constructor' do
-      it 'return the project name' do
+      it 'returns the project name' do
         config = Liftoff::ProjectConfiguration.new({
           :project_name => 'My Cool Project'
         })
@@ -121,9 +121,11 @@ describe Liftoff::ProjectConfiguration do
 
     end
 
-    context 'when the path is given by constructor' do
-      it 'return the given path' do
-        config = Liftoff::ProjectConfiguration.new({}, 'Another Path')
+    context 'when the path is given in the constructor' do
+      it 'returns the given path' do
+        config = Liftoff::ProjectConfiguration.new({
+            :path => 'Another Path'
+        })
 
         expect(config.path).to eq 'Another Path'
       end


### PR DESCRIPTION
The CLI command now optionally takes a path to use as destination for
the project. If now path is given by the user, the default of the
project name is used.