### PR TITLE
Add header comment to default AppDelegate.swift

### DIFF
--- a/templates/AppDelegate.swift
+++ b/templates/AppDelegate.swift
@@ -1,3 +1,11 @@
+//
+//  AppDelegate.swift
+//  <%= project_name %>
+//
+//  Created by <%= author %> on <%= Time.now.strftime("%-m/%-d/%y") %>
+//  Copyright (c) <%= Time.now.strftime('%Y') %> <%= company %>. All rights reserved.
+//
+
 import UIKit
 
 @UIApplicationMain


### PR DESCRIPTION
This is the default for files from Xcode. Even though we at thoughtbot dislike
these header comments, we should use the default behavior here for Liftoff.
This file is easily overridden by a custom app delegate template, so removing
these comments is trivial.

ping @thoughtbot/ios