### PR TITLE
Let users add arbitrary configuration to tests

### DIFF
--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -88,7 +88,7 @@ module Liftoff
     end
 
     def perform_extra_config
-      xcode_helper.perform_extra_config(@config.extra_config)
+      xcode_helper.perform_extra_config(@config.extra_config, @config.extra_test_config)
     end
 
     def enable_static_analyzer

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -19,6 +19,7 @@ module Liftoff
       :strict_prompts,
       :xcode_command,
       :extra_config,
+      :extra_test_config,
       :deployment_target
 
     attr_writer :author,

--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -54,19 +54,17 @@ module Liftoff
     end
 
     def perform_extra_config(app_config, test_config)
-      [app_config, test_config].each do |config|
+      {app_config => target, test_config => test_target}.each do |config, t|
         if config
           config.each do |name, settings|
             if name.downcase == "all"
-              object = target
+              object = t
             else
-              object = target.build_settings(name)
+              object = t.build_settings(name)
             end
 
             if object
-              settings.each do |key, value|
-                object[key] = value
-              end
+              object.merge!(settings)
             end
           end
         end
@@ -80,19 +78,23 @@ module Liftoff
     private
 
     def target
-      @target ||= ObjectPicker.choose_item('target', available_targets)
+      @target ||= ObjectPicker.choose_item('target', application_targets)
     end
 
     def test_target
-      @test_target ||= ObjectPicker.choose_item('test target', available_test_targets)
+      @test_target ||= ObjectPicker.choose_item('test target', test_targets)
     end
 
-    def available_targets
-      xcode_project.targets.to_a.reject { |t| t.name.end_with?('Tests') }
+    def all_targets
+      xcode_project.targets.to_a
     end
 
-    def available_targets
-      xcode_project.targets.to_a.select { |t| t.name.end_with?('Tests') }
+    def application_targets
+      all_targets.reject { |t| t.name.end_with?('Tests') }
+    end
+
+    def test_targets
+      all_targets.select { |t| t.name.end_with?('Tests') }
     end
 
     def add_shell_script_build_phase(script, name, index)

--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -5,7 +5,7 @@ module Liftoff
     def treat_warnings_as_errors(enable_errors)
       if enable_errors
         puts 'Setting GCC_TREAT_WARNINGS_AS_ERRORS for Release builds'
-        target.build_settings('Release')['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
+        application_target.build_settings('Release')['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
       end
     end
 
@@ -54,13 +54,13 @@ module Liftoff
     end
 
     def perform_extra_config(app_config, test_config)
-      {app_config => target, test_config => test_target}.each do |config, t|
+      {app_config => application_target, test_config => test_target}.each do |config, target|
         if config
           config.each do |name, settings|
             if name.downcase == "all"
-              object = t
+              object = target
             else
-              object = t.build_settings(name)
+              object = target.build_settings(name)
             end
 
             if object
@@ -77,7 +77,7 @@ module Liftoff
 
     private
 
-    def target
+    def application_target
       @target ||= ObjectPicker.choose_item('target', application_targets)
     end
 
@@ -99,18 +99,18 @@ module Liftoff
 
     def add_shell_script_build_phase(script, name, index)
       if build_phase_does_not_exist_with_name?(name)
-        build_phase = target.new_shell_script_build_phase(name)
+        build_phase = application_target.new_shell_script_build_phase(name)
         build_phase.shell_script = script
 
-        target.build_phases.delete(build_phase)
-        target.build_phases.insert(index, build_phase)
+        application_target.build_phases.delete(build_phase)
+        application_target.build_phases.insert(index, build_phase)
 
         xcode_project.save
       end
     end
 
     def build_phase_does_not_exist_with_name?(name)
-      target.build_phases.to_a.none? { |phase| phase.display_name == name }
+      application_target.build_phases.to_a.none? { |phase| phase.display_name == name }
     end
 
     def file_manager

--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -85,16 +85,16 @@ module Liftoff
       @test_target ||= ObjectPicker.choose_item('test target', test_targets)
     end
 
-    def all_targets
-      xcode_project.targets.to_a
-    end
-
     def application_targets
       all_targets.reject { |t| t.name.end_with?('Tests') }
     end
 
     def test_targets
       all_targets.select { |t| t.name.end_with?('Tests') }
+    end
+
+    def all_targets
+      xcode_project.targets.to_a
     end
 
     def add_shell_script_build_phase(script, name, index)

--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -53,18 +53,20 @@ module Liftoff
       end
     end
 
-    def perform_extra_config(extra_config)
-      if extra_config
-        extra_config.each do |name, settings|
-          if name.downcase == "all"
-            object = target
-          else
-            object = target.build_settings(name)
-          end
+    def perform_extra_config(app_config, test_config)
+      [app_config, test_config].each do |config|
+        if config
+          config.each do |name, settings|
+            if name.downcase == "all"
+              object = target
+            else
+              object = target.build_settings(name)
+            end
 
-          if object
-            settings.each do |key, value|
-              object[key] = value
+            if object
+              settings.each do |key, value|
+                object[key] = value
+              end
             end
           end
         end
@@ -81,8 +83,16 @@ module Liftoff
       @target ||= ObjectPicker.choose_item('target', available_targets)
     end
 
+    def test_target
+      @test_target ||= ObjectPicker.choose_item('test target', available_test_targets)
+    end
+
     def available_targets
       xcode_project.targets.to_a.reject { |t| t.name.end_with?('Tests') }
+    end
+
+    def available_targets
+      xcode_project.targets.to_a.select { |t| t.name.end_with?('Tests') }
     end
 
     def add_shell_script_build_phase(script, name, index)

--- a/lib/liftoff/xcodeproj_monkeypatch.rb
+++ b/lib/liftoff/xcodeproj_monkeypatch.rb
@@ -7,6 +7,12 @@ module Xcodeproj
             configuration.build_settings[key] = value
           end
         end
+
+        def merge!(hash)
+          hash.each do |key, value|
+            self[key] = value
+          end
+        end
       end
     end
   end

--- a/man/liftoffrc.5
+++ b/man/liftoffrc.5
@@ -287,12 +287,21 @@ Set this key to
 .Ic false
 to disable the automatic-open functionality
 .It Ic extra_config
-type: array of dictionaries
+type: dictionary
 .br
 default: none
 .Pp
 Add additional per-configuration settings to the main application target. By
 default this key isn't set. See
+.Sx EXTRA CONFIGURATION
+for more information on the format of this key.
+.It Ic extra_test_config
+type: dictionary
+.br
+default: none
+.Pp
+Add additional per-configuration settings to the test target. By default this
+key isn't set. See
 .Sx EXTRA CONFIGURATION
 for more information on the format of this key.
 .El
@@ -559,13 +568,15 @@ in your
 .Sh EXTRA CONFIGURATION
 .Ic liftoff
 can perform additional arbitrary configuration to the main application target
-on a per-build configuration basis. In order to add arbitrary settings, you
-should add keys to the
+or the test target on a per-build configuration basis. In order to add
+arbitrary settings, you should add the
 .Ic extra_config
+or the
+.Ic extra_test_config
 key in your
-.Nm
-that correspond to the build configuration you'd like to modify. For example,
-to set all warnings on your
+.Nm ,
+and add dictionaries that correspond to the build configuration you'd like to
+modify. For example, to set all warnings on your
 .Ic Debug
 build configuration, you can set the following:
 .Pp
@@ -579,7 +590,7 @@ extra_config:
 Note that the key for the build configuration must match the name of the build
 configuration you'd like to modify exactly.
 .Pp
-If you would like to set a project-wide setting for the application target, you
+If you would like to add a setting for all available build configurations, you
 can use the special
 .Ic all
 key in the configuration:


### PR DESCRIPTION
This adds the `extra_test_config` key to the `liftoffrc`. This key acts 
similarly to the `extra_config` key, but adds arbitrary configuration to the
test target. If more than one test target exists, the user will be given the
chance to select the target they would like to modify.

Fixes #193