### PR TITLE
[WIP] Adding support to creating custom build_configurations

### DIFF
--- a/lib/liftoff.rb
+++ b/lib/liftoff.rb
@@ -8,6 +8,7 @@ require 'find'
 require 'highline/import'
 require 'xcodeproj'
 
+require 'liftoff/build_configuration_builder'
 require 'liftoff/cli'
 require "liftoff/dependency_manager_coordinator"
 require "liftoff/dependency_manager"

--- a/lib/liftoff/build_configuration_builder.rb
+++ b/lib/liftoff/build_configuration_builder.rb
@@ -1,0 +1,20 @@
+module Liftoff
+  class BuildConfigurationBuilder
+    def initialize(xcode_project)
+      @xcode_project = xcode_project
+    end
+
+    def generate_build_configuration(name, type)
+      @xcode_project.add_build_configuration(name, type.to_sym)
+    end
+
+    def generate_build_configurations(build_configurations)
+      build_configurations ||= []
+      build_configurations.each do |configuration|
+        name = configuration["name"]
+        type = configuration["type"]
+        generate_build_configuration(name, type)
+      end
+    end
+  end
+end

--- a/lib/liftoff/project.rb
+++ b/lib/liftoff/project.rb
@@ -6,6 +6,7 @@ module Liftoff
       @test_target_name = configuration.test_target_name
       set_company_name(configuration.company)
       set_prefix(configuration.prefix)
+      create_build_configurations(configuration.build_configurations)
       configure_base_project_settings
     end
 
@@ -68,6 +69,11 @@ module Liftoff
 
     def set_company_name(company)
       xcode_project.root_object.attributes['ORGANIZATIONNAME'] = company
+    end
+
+    def create_build_configurations(build_configurations)
+      builder = BuildConfigurationBuilder.new(xcode_project)
+      builder.generate_build_configurations(build_configurations)
     end
 
     def new_test_target(name)

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -22,7 +22,8 @@ module Liftoff
       :extra_config,
       :extra_test_config,
       :deployment_target,
-      :schemes
+      :schemes,
+      :build_configurations
 
     attr_writer :author,
       :company_identifier,

--- a/man/liftoffrc.5
+++ b/man/liftoffrc.5
@@ -293,6 +293,15 @@ file if it can't find one.
 Set this key to
 .Ic false
 to disable the automatic-open functionality
+.It Ic build_configurations
+type: dictionary
+.br
+default: none
+.Pp
+Add additional build configurations to the project.
+By default this key isn't set. See
+.Sx BUILD CONFIGURATIONS
+for more information on the format of this key.
 .It Ic extra_config
 type: dictionary
 .br
@@ -595,6 +604,46 @@ on the command line, or even make it your default by setting
 .Ic project_template
 in your
 .Nm .
+.
+.Sh BUILD CONFIGURATIONS
+.Ic liftoff
+can add additional build configurations to the project. In order to do
+it, you should add the
+.Ic build_configurations
+key in your
+.Nm ,
+and add dictionaries that correspond to the build configurations you'd like to
+add.
+.Pp
+A new build configuration can either be of
+.Ic debug
+type or
+.Ic release .
+.Pp
+For example, you can create build configurations that will be used when
+uploading to the App Store:
+.Pp
+.Bd -literal
+build_configurations:
+  - name: Debug-AppStore
+    type: debug
+  - name: Release-AppStore
+    type: release
+.Ed
+.Pp
+Note that the value of
+.Ic type
+key must be either
+.Ic debug
+or
+.Ic release.
+.
+.Pp
+You can use the created build configurations to create a scheme with the
+.Pa schemes
+key. You can also customize the created configurations with the
+.Pa extra_config
+key.
 .
 .Sh EXTRA CONFIGURATION
 .Ic liftoff

--- a/spec/build_configuration_builder_specs.rb
+++ b/spec/build_configuration_builder_specs.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe Liftoff::BuildConfigurationBuilder do
+  describe "#generate_build_configuration" do
+    it "creates a build configuration" do
+      project = double("xcodeproj")
+      builder = build_configuration_builder(project)
+
+      allow(project).to receive(:add_build_configuration)
+
+      builder.generate_build_configuration("Release-CI", :release)
+
+      expect(project).to have_received(:add_build_configuration).with("Release-CI", :release)
+    end
+  end
+
+  describe "#generate_build_configurations" do
+    it "creates multiple build configurations" do
+      project = double("xcodeproj")
+      builder = build_configuration_builder(project)
+
+      allow(project).to receive(:add_build_configuration)
+
+      builder.generate_build_configurations(build_configurations)
+
+      expect(project).to have_received(:add_build_configuration).with("Release-CI", :release)
+      expect(project).to have_received(:add_build_configuration).with("Debug-CI", :debug)
+    end
+  end
+
+  def build_configurations
+    [
+        {
+            "name" => "Release-CI",
+            "type" => "release",
+        },
+        {
+            "name" => "Debug-CI",
+            "type" => "debug",
+        },
+    ]
+  end
+
+  def build_configuration_builder(project)
+    Liftoff::BuildConfigurationBuilder.new(project)
+  end
+end

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -178,6 +178,26 @@ describe Liftoff::ProjectConfiguration do
     end
   end
 
+  describe "#build_configurations" do
+    it "returns an array of build configurations" do
+      build_configurations = [
+        {
+          "name" => "Debug-CI",
+          "type" => "debug",
+        },
+        {
+          "name" => "Release-CI",
+          "type" => "release",
+        },
+      ]
+
+      config = Liftoff::ProjectConfiguration.new({})
+      config.build_configurations = build_configurations
+
+      expect(config.build_configurations).to eq(build_configurations)
+    end
+  end
+
   def build_config(name)
     app_templates = build_templates('app')
     test_templates = build_templates('test')


### PR DESCRIPTION
This enables creation of custom build configurations by adding `build_configurations` to `.liftoffrc`:

```yaml
build_configurations:
    - name: Debug-CI
      type: debug
    - name: Release-CI
      type: release
```

`type` must be `release` or `debug` (or else it'll error in `add_build_configuration`). As `xcodeproj` itself doesn't explicitly checks for these, I followed the same rule. I also haven't checked if both `name` and `type` were specified as I haven't seen this pattern through the codebase.

`create_build_configurations` was called before `configure_base_project_settings` so all further configuration is also applied to the created configurations.

The created build configurations should be accessible from `extra_config`, but I haven't tested it yet.

**UPDATE**: I have tested using `extra_config` and it did work as expected.

Also, I haven't updated the documentation yet and haven't created tests for this (some help here would be greatly appreciated). 