### PR TITLE
Fix "framworks" typo in Carthage copy phase

### DIFF
--- a/lib/liftoff/dependency_managers/carthage.rb
+++ b/lib/liftoff/dependency_managers/carthage.rb
@@ -18,7 +18,7 @@ module Liftoff
       [
         {
           "file" => "copy_frameworks.sh",
-          "name" => "Copy framworks (Carthage)",
+          "name" => "Copy frameworks (Carthage)",
         }
       ]
     end


### PR DESCRIPTION
Just a simple copy fix I noticed while using this tool.