### PR TITLE
Improve test target detection in xcodeproj_helper

### DIFF
--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -111,7 +111,7 @@ module Liftoff
     end
 
     def xcode_helper
-      @xcode_helper ||= XcodeprojHelper.new
+      @xcode_helper ||= XcodeprojHelper.new(@config)
     end
 
     def file_manager

--- a/lib/liftoff/xcodeproj_helper.rb
+++ b/lib/liftoff/xcodeproj_helper.rb
@@ -2,6 +2,10 @@ module Liftoff
   class XcodeprojHelper
     LAST_INDEX = -1
 
+    def initialize(config)
+      @test_target_name = config.test_target_name
+    end
+
     def treat_warnings_as_errors(enable_errors)
       if enable_errors
         puts 'Setting GCC_TREAT_WARNINGS_AS_ERRORS for Release builds'
@@ -86,11 +90,11 @@ module Liftoff
     end
 
     def application_targets
-      all_targets.reject { |t| t.name.end_with?('Tests') }
+      all_targets.reject { |t| t.name.end_with?(@test_target_name) }
     end
 
     def test_targets
-      all_targets.select { |t| t.name.end_with?('Tests') }
+      all_targets.select { |t| t.name.end_with?(@test_target_name) }
     end
 
     def all_targets


### PR DESCRIPTION
Now that we have customizable test target names, we can use that to
detect test targets instead of just looking for the suffix "Tests".

Fixes #218 (finally)