### PR TITLE
Add deprecation for `use_cocoapods`

### DIFF
--- a/lib/liftoff/deprecation_manager.rb
+++ b/lib/liftoff/deprecation_manager.rb
@@ -2,6 +2,7 @@ module Liftoff
   class DeprecationManager
     DEPRECATIONS = {
       :install_todo_script => 'run_script_phases',
+      :use_cocoapods => 'dependency_managers',
     }
 
     def initialize

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -14,7 +14,6 @@ module Liftoff
       :project_template,
       :app_target_templates,
       :test_target_templates,
-      :use_cocoapods,
       :dependency_managers,
       :run_script_phases,
       :strict_prompts,


### PR DESCRIPTION
We don't want people to use this anymore, so we should deprecate it
properly.