### PR TITLE
Add Bundler dependency manager

### DIFF
--- a/defaults/liftoffrc
+++ b/defaults/liftoffrc
@@ -26,7 +26,6 @@ run_script_phases:
 
 templates:
   - travis.yml: .travis.yml
-  - Gemfile.rb: Gemfile
   - test.sh: bin/test
   - setup.sh: bin/setup
   - README.md: README.md

--- a/lib/liftoff.rb
+++ b/lib/liftoff.rb
@@ -12,6 +12,7 @@ require 'liftoff/build_configuration_builder'
 require 'liftoff/cli'
 require "liftoff/dependency_manager_coordinator"
 require "liftoff/dependency_manager"
+require "liftoff/dependency_managers/bundler"
 require "liftoff/dependency_managers/carthage"
 require "liftoff/dependency_managers/cocoapods"
 require "liftoff/dependency_managers/null_dependency_manager"

--- a/lib/liftoff/cli.rb
+++ b/lib/liftoff/cli.rb
@@ -35,7 +35,9 @@ module Liftoff
           @options[:strict_prompts] = strict_prompts
         end
 
-        opts.on('--dependency-managers [NAME(s)]', 'Comma separated list of dependency managers to enable. Available options: cocoapods,carthage') do |list|
+        opts.on('--dependency-managers [NAME(s)]',
+                "Comma separated list of dependency managers to enable.\
+ Available options: cocoapods,carthage,bundler") do |list|
           @options[:dependency_managers] = (list || "").split(",")
         end
 

--- a/lib/liftoff/dependency_managers/bundler.rb
+++ b/lib/liftoff/dependency_managers/bundler.rb
@@ -1,0 +1,32 @@
+module Liftoff
+  class Bundler < DependencyManager
+    def setup
+      if bundler_installed?
+        move_gemfile
+      else
+        puts "Please install Bundler or disable bundler from liftoff"
+      end
+    end
+
+    def install
+      if bundler_installed?
+        run_bundle_install
+      end
+    end
+
+    private
+
+    def bundler_installed?
+      system("which bundle > /dev/null")
+    end
+
+    def move_gemfile
+      FileManager.new.generate("Gemfile.rb", "Gemfile", config)
+    end
+
+    def run_bundle_install
+      puts "Running bundle install"
+      system("bundle install")
+    end
+  end
+end

--- a/lib/liftoff/launchpad.rb
+++ b/lib/liftoff/launchpad.rb
@@ -124,7 +124,7 @@ module Liftoff
     end
 
     def dependency_managers
-      @dependency_managers ||= [cocoapods, carthage]
+      @dependency_managers ||= [cocoapods, carthage, bundler]
     end
 
     def cocoapods
@@ -138,6 +138,14 @@ module Liftoff
     def carthage
       if @config.dependency_manager_enabled?("carthage")
         Carthage.new(@config)
+      else
+        NullDependencyManager.new(@config)
+      end
+    end
+
+    def bundler
+      if @config.dependency_manager_enabled?("bundler")
+        Bundler.new(@config)
       else
         NullDependencyManager.new(@config)
       end

--- a/man/liftoffrc.5
+++ b/man/liftoffrc.5
@@ -149,7 +149,7 @@ affect the default templates. If you choose to be incorrect with your
 indentation settings, we recommend that you also override the default templates
 in order to be consistently wrong.
 .It Ic dependency_managers
-type: array 
+type: array
 .br
 default:
 .Ic cocoapods
@@ -157,9 +157,10 @@ default:
 Specify the dependency managers to use.
 .Pp
 Currently, this accepts
-.Ic cocoapods
+.Ic cocoapods ,
+.Ic carthage ,
 and/or
-.Ic carthage
+.Ic bundler
 as options. For each dependency manager listed,
 .Ic liftoff
 will install the default dependency file, as well as perform any necessary
@@ -492,9 +493,10 @@ This template is installed to
 .Pa Gemfile ,
 and contains a set of default gems for use with the project. Right now, it
 contains
-.Ic CocoaPods
+.Ic XCPretty
 and
-.Ic XCPretty .
+.Ic CocoaPods
+if the cocoapods dependency manager is enabled.
 .It Pa test.sh
 This template is installed to
 .Pa bin/test

--- a/spec/dependency_managers/bundler_spec.rb
+++ b/spec/dependency_managers/bundler_spec.rb
@@ -1,0 +1,70 @@
+require "spec_helper"
+
+RSpec.describe Liftoff::Bundler do
+  describe "#setup" do
+    it "checks to see if bundler is installed" do
+      system_call = "which bundle > /dev/null"
+      bundler = Liftoff::Bundler.new(:config)
+      allow(bundler).to receive(:system).with(system_call)
+
+      bundler.setup
+
+      expect(bundler).to have_received(:system).with(system_call)
+    end
+
+    context "when bundler is installed" do
+      it "asks FileManager to move the Gemfile" do
+        bundler = Liftoff::Bundler.new(:config)
+        allow(bundler).to receive(:bundler_installed?).and_return(true)
+        arguments = ["Gemfile.rb", "Gemfile", :config]
+        file_manager = double("FileManager")
+        allow(Liftoff::FileManager).to receive(:new).and_return(file_manager)
+        allow(file_manager).to receive(:generate).with(*arguments)
+
+        bundler.setup
+
+        expect(file_manager).to have_received(:generate).with(*arguments)
+      end
+    end
+
+    context "when bundler is not installed" do
+      it "puts a message out to the system" do
+        bundler = Liftoff::Bundler.new(:config)
+        output_string = "Please install Bundler or disable bundler from liftoff"
+        allow(bundler).to receive(:bundler_installed?).and_return(false)
+        allow(bundler).to receive(:puts).with(output_string)
+
+        bundler.setup
+
+        expect(bundler).to have_received(:puts).with(output_string)
+      end
+    end
+  end
+
+  describe "#install" do
+    context "if bundler is installed" do
+      it "runs bundle install" do
+        bundler = Liftoff::Bundler.new(:config)
+        allow(bundler).to receive(:bundler_installed?).and_return(true)
+        system_call = "bundle install"
+        allow(bundler).to receive(:system).with(system_call)
+
+        bundler.install
+
+        expect(bundler).to have_received(:system).with(system_call)
+      end
+    end
+
+    context "if bundler is not installed" do
+      it "does not run bundle install" do
+        bundler = Liftoff::Bundler.new(:config)
+        allow(bundler).to receive(:bundler_installed?).and_return(false)
+        allow(bundler).to receive(:system)
+
+        bundler.install
+
+        expect(bundler).not_to have_received(:system)
+      end
+    end
+  end
+end

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
+<% if dependency_manager_enabled?("bundler") %>
 bundle install
+<% end %>
 <% if enable_settings && dependency_manager_enabled?("cocoapods") %>
 pod install
 <% end %>


### PR DESCRIPTION
This adds bundler as a dependency manager. It seems to work (copies files, runs `bundle install`) but because I'm not deeply familiar with Xcode I wouldn't be surprised if there was something obvious missing. I'd love to see someone who knows better than I do actually run this and see if it does what they would expect.

cc @keith because you requested it initially

Resolves #156 