### PR TITLE
Bump Dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :dist do
-  gem 'xcodeproj', '~> 0.27.1'
+  gem 'xcodeproj', '~> 0.28.2'
   gem 'highline', '~> 1.6'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.4)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -13,7 +13,7 @@ GEM
     highline (1.6.21)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.0)
+    minitest (5.8.3)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -30,7 +30,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    xcodeproj (0.27.1)
+    xcodeproj (0.28.2)
       activesupport (>= 3)
       claide (~> 0.9.1)
       colored (~> 1.2)
@@ -41,7 +41,4 @@ PLATFORMS
 DEPENDENCIES
   highline (~> 1.6)
   rspec
-  xcodeproj (~> 0.27.1)
-
-BUNDLED WITH
-   1.10.6
+  xcodeproj (~> 0.28.2)


### PR DESCRIPTION
I was experiencing some unwanted output on OS X El Capitan, which was generated by Xcodeproj.
![output](https://cloud.githubusercontent.com/assets/2678345/11731452/cd18125e-9f9b-11e5-9abc-179e1af72838.png)
This unwanted output has been muted in a newer version (https://github.com/CocoaPods/Xcodeproj/pull/312) and this commit simply bumps the dependencies.