### PR TITLE
Use SHA256 checksum algorithm in Homebrew formula

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ namespace :homebrew do
     task :build do
       formula = File.read('homebrew/liftoff.rb')
       formula.gsub!('__VERSION__', Liftoff::VERSION)
-      formula.gsub!('__SHA__', `shasum #{GH_PAGES_DIR}/Liftoff-#{Liftoff::VERSION}.tar.gz`.split.first)
+      formula.gsub!('__SHA__', `shasum -a 256 #{GH_PAGES_DIR}/Liftoff-#{Liftoff::VERSION}.tar.gz`.split.first)
       File.write("#{HOMEBREW_FORMULAE_DIR}/Formula/liftoff.rb", formula)
     end
   end

--- a/homebrew/liftoff.rb
+++ b/homebrew/liftoff.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Liftoff < Formula
   homepage 'https://github.com/thoughtbot/liftoff'
   url 'http://thoughtbot.github.io/liftoff/Liftoff-__VERSION__.tar.gz'
-  sha1 '__SHA__'
+  sha256 '__SHA__'
 
   depends_on 'xcproj' => :recommended
 


### PR DESCRIPTION
This fixed Homebrew warning about `SHA1` being deprecated and to be removed soon.

Please note that I didn't actually run it so most likely you will want to test it before merging this PR.