### PR TITLE
fix #273

### DIFF
--- a/defaults/liftoffrc
+++ b/defaults/liftoffrc
@@ -30,6 +30,9 @@ templates:
   - setup.sh: bin/setup
   - README.md: README.md
 
+additional_resource_suffixes:
+  - txt
+
 warnings:
   - GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED
   - GCC_WARN_MISSING_PARENTHESES

--- a/lib/liftoff/project_builder.rb
+++ b/lib/liftoff/project_builder.rb
@@ -88,7 +88,13 @@ module Liftoff
     end
 
     def resource_file?(name)
-      name.end_with?('xcassets', 'bundle', 'xib', 'storyboard')
+      suffixes = ['xcassets', 'bundle', 'xib', 'storyboard'].concat(@config.additional_resource_suffixes)
+      suffixes.each do |suffix|
+        if name.end_with?(suffix)
+          return true
+        end
+      end 
+      return false
     end
 
     def template_file?(object)

--- a/lib/liftoff/project_configuration.rb
+++ b/lib/liftoff/project_configuration.rb
@@ -11,6 +11,7 @@ module Liftoff
       :indentation_level,
       :warnings,
       :templates,
+      :additional_resource_suffixes,
       :project_template,
       :app_target_templates,
       :test_target_templates,
@@ -64,6 +65,10 @@ module Liftoff
       templates.each do |template|
         template.each_pair(&block)
       end
+    end
+
+    def additional_resource_suffixes
+      @additional_resource_suffixes ||= []
     end
 
     def get_binding

--- a/spec/project_configuration_spec.rb
+++ b/spec/project_configuration_spec.rb
@@ -73,6 +73,16 @@ describe Liftoff::ProjectConfiguration do
     end
   end
 
+  describe '#additional_resource_suffixes' do
+    it 'returns an array of suffixes' do
+      additional_resource_suffixes = ['foo', 'bar']
+
+      config = Liftoff::ProjectConfiguration.new({:additional_resource_suffixes => additional_resource_suffixes})
+
+      expect(config.additional_resource_suffixes).to eq(['foo', 'bar'])
+    end
+  end
+
   describe '#app_target_groups' do
     context 'when the project_template is set to swift' do
       it 'returns the swift app target groups' do

--- a/templates/resource_test.txt
+++ b/templates/resource_test.txt
@@ -1,0 +1,1 @@
+txt test


### PR DESCRIPTION
## Summary

Here's an implementation of a possible improvement linked to issue #273.
Please do review it carefully as Ruby isn't my strong suit.
## Feature

You can now optionally specify an array of suffixes that need to be processed by liftoff as resource (ie not be added to the `Compile Sources` phase), using the key `additional_resource_suffixes`.
## Example

``` yaml
additional_resource_suffixes:
 - txt
 - yaml
 - ttf
```
## Test

See https://github.com/kirualex/liftoff/blob/feature/%23273/spec/project_configuration_spec.rb#L76-L84
