### PR TITLE
Fix TODO build phase not ignoring Carthage directory

### DIFF
--- a/templates/todo.sh
+++ b/templates/todo.sh
@@ -1,3 +1,3 @@
 KEYWORDS="TODO:|FIXME:|\?\?\?:|\!\!\!:"
 FILE_EXTENSIONS="swift|h|m|mm|c|cpp"
-find -E "${SRCROOT}" -ipath "${SRCROOT}/Carthage" -o -ipath "${SRCROOT}/pods" -prune -o \( -regex ".*\.($FILE_EXTENSIONS)$" \) -print0 | xargs -0 egrep --with-filename --line-number --only-matching "($KEYWORDS).*\$" | perl -p -e "s/($KEYWORDS)/ warning: \$1/"
+find -E "${SRCROOT}" -ipath "${SRCROOT}/Carthage" -prune -o -ipath "${SRCROOT}/pods" -prune -o \( -regex ".*\.($FILE_EXTENSIONS)$" \) -print0 | xargs -0 egrep --with-filename --line-number --only-matching "($KEYWORDS).*\$" | perl -p -e "s/($KEYWORDS)/ warning: \$1/"


### PR DESCRIPTION
The `find` command was midding the `-prune` for the Carthage dir which made it
_not_ ignore Carthage. Adding the `prune` option now correctly ignores the
directory and doesn't warn on any todo/fixmes within it.