### PR TITLE
Bump dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :dist do
-  gem 'xcodeproj', '~> 0.28.2'
-  gem 'highline', '~> 1.6'
+  gem 'xcodeproj', '~> 1.0'
+  gem 'highline', '~> 1.7'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5)
+    activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    claide (0.9.1)
+    claide (1.0.0)
     colored (1.2)
     diff-lcs (1.2.5)
-    highline (1.6.21)
+    highline (1.7.8)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.3)
+    minitest (5.9.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -30,15 +30,18 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    xcodeproj (0.28.2)
+    xcodeproj (1.1.0)
       activesupport (>= 3)
-      claide (~> 0.9.1)
+      claide (>= 1.0.0, < 2.0)
       colored (~> 1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  highline (~> 1.6)
+  highline (~> 1.7)
   rspec
-  xcodeproj (~> 0.28.2)
+  xcodeproj (~> 1.0)
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
This should remove warnings when running cocoapods commands about conflicting
versions of xcodeproj