### PR TITLE
Swap Travis configuration with Circle

### DIFF
--- a/defaults/liftoffrc
+++ b/defaults/liftoffrc
@@ -25,7 +25,7 @@ run_script_phases:
     name: Set version number
 
 templates:
-  - travis.yml: .travis.yml
+  - circle.yml: .circle.yml
   - test.sh: bin/test
   - setup.sh: bin/setup
   - README.md: README.md

--- a/man/liftoffrc.5
+++ b/man/liftoffrc.5
@@ -484,10 +484,10 @@ meaning.
 .Ic liftoff
 installs a number of templates by default:
 .Bl -tag -width 10
-.It Pa travis.yml
+.It Pa circle.yml
 This template is installed to
-.Pa .travis.yml ,
-and contains a default setup for Travis integration.
+.Pa circle.yml ,
+and contains a default setup for CircleCI integration.
 .It Pa Gemfile.rb
 This template is installed to
 .Pa Gemfile ,
@@ -502,7 +502,7 @@ This template is installed to
 .Pa bin/test
 and enables the running of tests from the command line. This is used by the
 default
-.Pa travis.yml
+.Pa circle.yml
 template to determine build status.
 .El
 .Pp
@@ -510,13 +510,13 @@ template to determine build status.
 expects templates in the following format:
 .Pp
 .Bd -literal
-  - travis.yml: .travis.yml
+  - circle.yml: circle.yml
 .Ed
 .Pp
 This will install the template named
-.Pa travis.yml
+.Pa circle.yml
 found inside the templates directory to
-.Pa .travis.yml
+.Pa circle.yml
 inside the project directory.
 .Pp
 This file will be parsed with ERB with the project configuration, giving you

--- a/templates/circle.yml
+++ b/templates/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  xcode:
+    version: "7.3"
+
+test:
+  override:
+    - bin/test -r

--- a/templates/test.sh
+++ b/templates/test.sh
@@ -1,5 +1,45 @@
-#!/usr/bin/env bash
+#!/bin/bash
+#
+# Runs tests via xcodebuild, formatting results with xcpretty.
+#
+# Usage: bin/test [options]
+#
+# Options:
+#   -k    Clean before running the tests.
+#   -r    Emit JUnit XML report.
+#   -t    Use RSpec-style test output.
 
-set -o pipefail
+set -eo pipefail
 
-xcodebuild test -workspace <%= project_name %>.xcworkspace -scheme <%= project_name %> -sdk iphonesimulator BUILD_ACTIVE_ARCH=NO | xcpretty -t -c
+build_actions=(test)
+test_reports_dir="${CIRCLE_TEST_REPORTS:-build}"
+xcpretty_options=(--color)
+
+while getopts krt opt; do
+  case ${opt} in
+    k)
+      build_actions=(clean test)
+      ;;
+    r)
+      xcpretty_options+=(--report junit --output "${test_reports_dir}/test-report.xml")
+      ;;
+    t)
+      xcpretty_options+=(--test)
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+mkdir -p "${test_reports_dir}"
+
+env NSUnbufferedIO=YES xcrun xcodebuild \
+  -workspace <%= project_name %>.xcworkspace \
+  -scheme <%= project_name %> \
+  -sdk iphonesimulator \
+  BUILD_ACTIVE_ARCH=NO \
+  "${build_actions[@]}" \
+  | xcpretty "${xcpretty_options[@]}"


### PR DESCRIPTION
We use Circle as a default now because it seems to work better than the others.
Since we don't use Travis anymore, this also makes it so we don't need to
maintain a configuration for it.
